### PR TITLE
fix(v2): Atlantis JSON decoding and parallel execution conflicts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,7 +58,7 @@ jobs:
             type=ref,event=pr
             type=semver,pattern=v{{major}},enable=${{ github.event_name == 'push' && contains(github.ref, 'refs/tags/') }}
           images: |
-            ghcr.io/cresta/atlantis-drift-detection
+            ghcr.io/shkrid/atlantis-drift-detection
       - name: Build and push
         uses: docker/build-push-action@v6
         with:

--- a/action.yml
+++ b/action.yml
@@ -7,4 +7,4 @@ runs:
   using: 'docker'
   # TODO: Figure out a way to auto update this. It's very useful for speeding up the action to not have it build the
   # container each run
-  image: 'docker://ghcr.io/cresta/atlantis-drift-detection:v1'
+  image: 'docker://ghcr.io/shkrid/atlantis-drift-detection:v2'

--- a/cmd/atlantis-drift-detection/main.go
+++ b/cmd/atlantis-drift-detection/main.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/cresta/atlantis-drift-detection/internal/atlantis"
@@ -16,25 +17,29 @@ import (
 	"github.com/cresta/gogithub"
 	"github.com/joho/godotenv"
 
+	"github.com/joeshaw/envdecode"
 	// Empty import allows pinning to version atlantis uses
 	_ "github.com/nlopes/slack"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 )
-import "github.com/joeshaw/envdecode"
 
 type config struct {
 	Repo               string        `env:"REPO,required"`
+	RepoBranch         string        `env:"BRANCH,default=master"`
 	AtlantisHostname   string        `env:"ATLANTIS_HOST,required"`
 	AtlantisToken      string        `env:"ATLANTIS_TOKEN,required"`
 	DirectoryWhitelist []string      `env:"DIRECTORY_WHITELIST"`
 	SlackWebhookURL    string        `env:"SLACK_WEBHOOK_URL"`
-	SkipWorkspaceCheck bool          `env:"SKIP_WORKSPACE_CHECK"`
+	SlackToken         string        `env:"SLACK_TOKEN"`
+	SlackChannel       string        `env:"SLACK_CHANNEL"`
+	SkipWorkspaceCheck bool          `env:"SKIP_WORKSPACE_CHECK,default=true"`
 	ParallelRuns       int           `env:"PARALLEL_RUNS"`
 	DynamodbTable      string        `env:"DYNAMODB_TABLE"`
 	CacheValidDuration time.Duration `env:"CACHE_VALID_DURATION,default=24h"`
 	WorkflowOwner      string        `env:"WORKFLOW_OWNER"`
 	WorkflowRepo       string        `env:"WORKFLOW_REPO"`
-	WorkflowId         string        `env:"WORKFLOW_ID"`
+	WorkflowId         string        `env:"WORKFLOW_ID,default=atlantis-drift-detection.yaml"`
 	WorkflowRef        string        `env:"WORKFLOW_REF"`
 }
 
@@ -74,10 +79,23 @@ func (z *zapGogitLogger) Info(_ context.Context, msg string, strings map[string]
 
 var _ gogit.Logger = (*zapGogitLogger)(nil)
 
+func getLogLevel() zapcore.Level {
+	switch strings.ToLower(os.Getenv("LOG_LEVEL")) {
+	case "debug":
+		return zap.DebugLevel
+	case "warn":
+		return zap.WarnLevel
+	case "error":
+		return zap.ErrorLevel
+	default:
+		return zap.InfoLevel
+	}
+}
+
 func main() {
 	ctx := context.Background()
 	zapCfg := zap.NewProductionConfig()
-	zapCfg.Level = zap.NewAtomicLevelAt(zap.DebugLevel)
+	zapCfg.Level = zap.NewAtomicLevelAt(getLogLevel())
 	logger, err := zapCfg.Build(zap.AddCaller())
 	if err != nil {
 		panic(err)
@@ -89,6 +107,14 @@ func main() {
 	if err := envdecode.Decode(&cfg); err != nil {
 		logger.Panic("failed to decode config", zap.Error(err))
 	}
+	if cfg.WorkflowOwner == "" && cfg.WorkflowRepo == "" {
+		if owner, repo, found := strings.Cut(cfg.Repo, "/"); found {
+			cfg.WorkflowOwner, cfg.WorkflowRepo = owner, repo
+		}
+	}
+	if cfg.WorkflowRef == "" {
+		cfg.WorkflowRef = cfg.RepoBranch
+	}
 	cloner := &gogit.Cloner{
 		Logger: &zapGogitLogger{logger},
 	}
@@ -97,9 +123,13 @@ func main() {
 			&notification.Zap{Logger: logger.With(zap.String("notification", "true"))},
 		},
 	}
-	if slackClient := notification.NewSlackWebhook(cfg.SlackWebhookURL, http.DefaultClient); slackClient != nil {
+	if slackClient := notification.NewSlackWebhook(cfg.SlackWebhookURL, http.DefaultClient, cfg.Repo); slackClient != nil {
 		logger.Info("setting up slack webhook notification")
 		notif.Notifications = append(notif.Notifications, slackClient)
+	}
+	if slackAPI := notification.NewSlackAPI(cfg.SlackToken, cfg.SlackChannel, cfg.Repo, http.DefaultClient); slackAPI != nil {
+		logger.Info("setting up slack api notification")
+		notif.Notifications = append(notif.Notifications, slackAPI)
 	}
 	var existingConfig *gogithub.NewGQLClientConfig
 	if os.Getenv("GITHUB_TOKEN") != "" {
@@ -130,10 +160,12 @@ func main() {
 		DirectoryWhitelist: cfg.DirectoryWhitelist,
 		Logger:             logger.With(zap.String("drifter", "true")),
 		Repo:               cfg.Repo,
+		Ref:        		cfg.RepoBranch,
 		AtlantisClient: &atlantis.Client{
 			AtlantisHostname: cfg.AtlantisHostname,
 			Token:            cfg.AtlantisToken,
 			HTTPClient:       http.DefaultClient,
+			Logger:           logger.With(zap.String("component", "atlantis-client")),
 		},
 		ParallelRuns:       cfg.ParallelRuns,
 		ResultCache:        cache,

--- a/internal/drifter/drifter.go
+++ b/internal/drifter/drifter.go
@@ -2,8 +2,10 @@ package drifter
 
 import (
 	"context"
-	"errors"
 	"fmt"
+	"os"
+	"time"
+
 	"github.com/cresta/atlantis-drift-detection/internal/atlantis"
 	"github.com/cresta/atlantis-drift-detection/internal/atlantisgithub"
 	"github.com/cresta/atlantis-drift-detection/internal/notification"
@@ -13,13 +15,12 @@ import (
 	"github.com/cresta/gogithub"
 	"go.uber.org/zap"
 	"golang.org/x/sync/errgroup"
-	"os"
-	"time"
 )
 
 type Drifter struct {
 	Logger             *zap.Logger
 	Repo               string
+	Ref                string
 	Cloner             *gogit.Cloner
 	GithubClient       gogithub.GitHub
 	Terraform          *terraform.Client
@@ -94,7 +95,9 @@ func (d *Drifter) drainAndExecute(ctx context.Context, toRun []errFunc) error {
 		return nil
 	})
 	for i := 0; i < d.ParallelRuns; i++ {
+		workerIndex := i
 		eg.Go(func() error {
+			workerCtx := context.WithValue(egctx, atlantis.WorkerIndexKey, workerIndex)
 			for {
 				select {
 				case <-egctx.Done():
@@ -103,7 +106,7 @@ func (d *Drifter) drainAndExecute(ctx context.Context, toRun []errFunc) error {
 					if !ok {
 						return nil
 					}
-					if err := r(egctx); err != nil {
+					if err := r(workerCtx); err != nil {
 						return err
 					}
 				}
@@ -144,17 +147,12 @@ func (d *Drifter) FindDriftedWorkspaces(ctx context.Context, ws atlantis.Directo
 
 				pr, err := d.AtlantisClient.PlanSummary(ctx, &atlantis.PlanSummaryRequest{
 					Repo:      d.Repo,
-					Ref:       "master",
+					Ref:       d.Ref,
 					Type:      "Github",
 					Dir:       dir,
 					Workspace: workspace,
 				})
 				if err != nil {
-					var tmp atlantis.TemporaryError
-					if errors.As(err, &tmp) && tmp.Temporary() {
-						d.Logger.Warn("Temporary error.  Will try again later.", zap.Error(err))
-						continue
-					}
 					return fmt.Errorf("failed to get plan summary for (%s#%s): %w", dir, workspace, err)
 				}
 				if err := d.ResultCache.StoreDriftCheckResult(ctx, cacheKey, &processedcache.DriftCheckValue{
@@ -171,6 +169,11 @@ func (d *Drifter) FindDriftedWorkspaces(ctx context.Context, ws atlantis.Directo
 				if pr.HasChanges() {
 					if err := d.Notification.PlanDrift(ctx, dir, workspace); err != nil {
 						return fmt.Errorf("failed to notify of plan drift in %s: %w", dir, err)
+					}
+				}
+				if pr.IsFailed() {
+					if err := d.Notification.PlanFailed(ctx, dir, workspace); err != nil {
+						return fmt.Errorf("failed to notify of plan failed in %s: %w", dir, err)
 					}
 				}
 			}

--- a/internal/notification/multi.go
+++ b/internal/notification/multi.go
@@ -6,9 +6,9 @@ type Multi struct {
 	Notifications []Notification
 }
 
-func (m *Multi) TemporaryError(ctx context.Context, dir string, workspace string, err error) error {
+func (m *Multi) PlanFailed(ctx context.Context, dir string, workspace string) error {
 	for _, n := range m.Notifications {
-		if err := n.TemporaryError(ctx, dir, workspace, err); err != nil {
+		if err := n.PlanFailed(ctx, dir, workspace); err != nil {
 			return err
 		}
 	}

--- a/internal/notification/notification.go
+++ b/internal/notification/notification.go
@@ -22,6 +22,5 @@ type Notification interface {
 	ExtraWorkspaceInRemote(ctx context.Context, dir string, workspace string) error
 	MissingWorkspaceInRemote(ctx context.Context, dir string, workspace string) error
 	PlanDrift(ctx context.Context, dir string, workspace string) error
-	// TemporaryError is called when an error occurs but we can't really tell what it means
-	TemporaryError(ctx context.Context, dir string, workspace string, err error) error
+	PlanFailed(ctx context.Context, dir string, workspace string) error
 }

--- a/internal/notification/slackapi.go
+++ b/internal/notification/slackapi.go
@@ -1,0 +1,84 @@
+package notification
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+type SlackAPI struct {
+	Token      string
+	Channel    string
+	HTTPClient *http.Client
+	Repo       string
+}
+
+type slackPostMessageRequest struct {
+	Channel string `json:"channel"`
+	Text    string `json:"text"`
+}
+
+type slackPostMessageResponse struct {
+	OK    bool   `json:"ok"`
+	Error string `json:"error"`
+}
+
+func NewSlackAPI(token, channel, repo string, httpClient *http.Client) *SlackAPI {
+	if token == "" || channel == "" {
+		return nil
+	}
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
+	return &SlackAPI{Token: token, Channel: channel, Repo: repo, HTTPClient: httpClient}
+}
+
+func (s *SlackAPI) post(ctx context.Context, text string) error {
+	body, _ := json.Marshal(slackPostMessageRequest{Channel: s.Channel, Text: text})
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, "https://slack.com/api/chat.postMessage", bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("failed to create slack request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+s.Token)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := s.HTTPClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to post slack message: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusTooManyRequests {
+		if ra := resp.Header.Get("Retry-After"); ra != "" {
+			// simple single retry after delay
+			t, _ := time.ParseDuration(ra + "s")
+			time.Sleep(t)
+			return s.post(ctx, text)
+		}
+	}
+	var out slackPostMessageResponse
+	_ = json.NewDecoder(resp.Body).Decode(&out)
+	if resp.StatusCode != http.StatusOK || !out.OK {
+		return fmt.Errorf("slack api error: status=%d ok=%v err=%s", resp.StatusCode, out.OK, out.Error)
+	}
+	return nil
+}
+
+func (s *SlackAPI) ExtraWorkspaceInRemote(ctx context.Context, dir string, workspace string) error {
+	return s.post(ctx, BuildSlackText("⚠️", "Extra workspace in remote", dir, workspace, s.Repo))
+}
+
+func (s *SlackAPI) MissingWorkspaceInRemote(ctx context.Context, dir string, workspace string) error {
+	return s.post(ctx, BuildSlackText("⚠️", "Missing workspace in remote", dir, workspace, s.Repo))
+}
+
+func (s *SlackAPI) PlanDrift(ctx context.Context, dir string, workspace string) error {
+	return s.post(ctx, BuildSlackText("🚨", "Plan Drift", dir, workspace, s.Repo))
+}
+
+func (s *SlackAPI) PlanFailed(ctx context.Context, dir string, workspace string) error {
+	return s.post(ctx, BuildSlackText("🔥", "Drift plan failed", dir, workspace, s.Repo))
+}
+
+var _ Notification = &SlackAPI{}

--- a/internal/notification/slackfmt.go
+++ b/internal/notification/slackfmt.go
@@ -1,0 +1,23 @@
+package notification
+
+import (
+	"fmt"
+	"net/url"
+)
+
+func BuildSlackText(emoji, title, dir, workspace, repo string) string {
+	text := fmt.Sprintf("%s *%s*\n", emoji, title)
+	dirLine := dir
+	if dir != "" && repo != "" {
+		encoded := url.QueryEscape(dir)
+		linkURL := fmt.Sprintf("https://github.com/%s/pulls?q=is%%3Apr+is%%3Aopen+label%%3A%s", repo, encoded)
+		dirLine = fmt.Sprintf("<%s|%s>", linkURL, dir)
+	}
+	if dirLine != "" {
+		text += fmt.Sprintf("*Directory*: %s\n", dirLine)
+	}
+	if workspace != "" {
+		text += fmt.Sprintf("*Workspace*: %s\n", workspace)
+	}
+	return text
+}

--- a/internal/notification/slackwebhook_test.go
+++ b/internal/notification/slackwebhook_test.go
@@ -1,13 +1,14 @@
 package notification
 
 import (
-	"github.com/cresta/atlantis-drift-detection/internal/testhelper"
 	"net/http"
 	"testing"
+
+	"github.com/cresta/atlantis-drift-detection/internal/testhelper"
 )
 
 func TestSlackWebhook_ExtraWorkspaceInRemote(t *testing.T) {
 	testhelper.ReadEnvFile(t, "../../")
-	wh := NewSlackWebhook(testhelper.EnvOrSkip(t, "SLACK_WEBHOOK_URL"), http.DefaultClient)
+	wh := NewSlackWebhook(testhelper.EnvOrSkip(t, "SLACK_WEBHOOK_URL"), http.DefaultClient, testhelper.EnvOrSkip(t, "REPO"))
 	genericNotificationTest(t, wh)
 }

--- a/internal/notification/zap.go
+++ b/internal/notification/zap.go
@@ -10,8 +10,8 @@ type Zap struct {
 	Logger *zap.Logger
 }
 
-func (I *Zap) TemporaryError(_ context.Context, dir string, workspace string, err error) error {
-	I.Logger.Error("Unknown error in remote", zap.String("dir", dir), zap.String("workspace", workspace), zap.Error(err))
+func (I *Zap) PlanFailed(_ context.Context, dir string, workspace string) error {
+	I.Logger.Warn("Drift plan failed", zap.String("dir", dir), zap.String("workspace", workspace))
 	return nil
 }
 


### PR DESCRIPTION
# Fix Atlantis JSON decoding and parallel execution conflicts

## 🐛 Problem

### 1. JSON Decoding Incompatibility
Atlantis API returns valid JSON, but Go's `json.Decoder` cannot unmarshal into `command.Result` structure because:
```
json: cannot unmarshal string into Go struct field Result.Error of type error
json: cannot unmarshal object into Go struct field ProjectResult.ProjectResults.Error of type error
```

The `error` type in Go doesn't implement `json.Unmarshaler`, so fields like `"Error": {}`, `"Error": null`, or `"Error": "string"` fail to decode.

### 2. Parallel Execution Conflicts  
Multiple workers using default `PR=0` create conflicting Atlantis workspace directories.

## ✅ Solution

- **Fixed JSON decoding** by replacing `error` fields with `any` type in custom DTOs
- **Implemented unique PR assignment** for parallel workers `(0, -1, -2, -3...)` to avoid workspace conflicts
- **Enhanced configuration** with smart defaults and Slack improvements

## 🔧 Changes Made

### **Core Fixes**
- Created tolerant `resultResponse` and `projectResult` structures with `Error any` fields
- Replaced `command.Result` dependency with internal DTOs that can decode any JSON error format
- **Worker-based PR assignment**: Each parallel worker gets unique negative PR to avoid Atlantis directory conflicts

### **Configuration Enhancements**

```bash
# New defaults:
WORKFLOW_ID=atlantis-drift-detection.yaml  # Default workflow filename
SKIP_WORKSPACE_CHECK=true                  # Skip validation by default
LOG_LEVEL=info                            # Configurable logging (debug/info/warn/error)
BRANCH=master                             # Repository branch setting
```

### **Slack Notifications**
- ✨ Rich formatting with emojis `(🚨, ⚠️, 🔍, ❌)` and **bold text**
- 🔗 Directory names link to GitHub PRs with label filters
- 📝 Conditional workspace display
- 🤖 New API method support: `SLACK_TOKEN`, `SLACK_CHANNEL`

### **Auto-parsing & Smart Defaults**
- 🔄 `WORKFLOW_OWNER` and `WORKFLOW_REPO` auto-extracted from `REPO`
- 🎯 `WorkflowRef` inherits from `RepoBranch` when not specified
- 📊 Configurable `LOG_LEVEL` environment variable

## 🏗️ Technical Details

### JSON Decoding Fix
```go
// Before: Can't decode JSON
type Result struct {
    Error error // ❌ Can't unmarshal JSON into error type
}

// After: Works with any JSON
type resultResponse struct {
    Error any   // ✅ Handles null, {}, "string", objects
}
```

### Parallel PR Assignment
Workers get unique PR numbers: `0, -1, -2, -3...` (negatives avoid conflicts with real GitHub PRs)

## ⚠️ Breaking Changes

| Setting | Before | After |
|---------|--------|-------|
| `SKIP_WORKSPACE_CHECK` | `false` | `true` |
| Default log level | `debug` | `info` |
